### PR TITLE
Remove hostname in cluster-run.sh

### DIFF
--- a/bin/cluster-run.sh
+++ b/bin/cluster-run.sh
@@ -41,7 +41,7 @@ fi
 USER_NAME='kis'
 
 #Remote hosts list
-HOSTS=( idevelopsrv20 idevelopsrv21 idevelopsrv22 idevelopsrv23 idevelopsrv24 )
+HOSTS=( HOSTNAME1 HOSTNAME2 )
 
 #Assuming all Gatling installation in same path (with write permissions)
 GATLING_LOCAL_HOME=gatling


### PR DESCRIPTION
Performance servers has been deleted.
We keep the script anyway.